### PR TITLE
Fix Helm Go Client CDC permissions

### DIFF
--- a/internal/templates/assets/deployment.yaml
+++ b/internal/templates/assets/deployment.yaml
@@ -30,6 +30,9 @@ spec:
       - name: {{ .resource }}-{{ .apiVersion }}-controller
         image: ghcr.io/krateoplatformops/composition-dynamic-controller:{{ or .tag "0.5.0" }}
         imagePullPolicy: IfNotPresent
+        env: 
+        - name: HOME # home should be set to /tmp or any other writable directory to avoid permission issues with helm https://github.com/helm/helm/issues/8038
+          value: /tmp
         args:
           - -debug
           - -group={{ .apiGroup }}


### PR DESCRIPTION
**Solution Implemented**
add $HOME env variable to change default home (default is '/' on containers)