### PR TITLE
Wrong naming of Resources in generated RBAC rules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/krateoplatformops/provider-runtime v0.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/stoewer/go-strcase v1.3.0
-	github.com/stretchr/testify v1.9.0
 	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.14.4
 	k8s.io/api v0.29.3
@@ -115,7 +114,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.19.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.52.3 // indirect

--- a/internal/controllers/compositiondefinitions/compositiondefinitions.go
+++ b/internal/controllers/compositiondefinitions/compositiondefinitions.go
@@ -10,6 +10,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -289,7 +290,7 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) error {
 	}
 
 	opts := deploy.DeployOptions{
-		DiscoveryClient: e.discovery,
+		DiscoveryClient: memory.NewMemCacheClient(e.discovery),
 		KubeClient:      e.kube,
 		NamespacedName: types.NamespacedName{
 			Namespace: cr.Namespace,
@@ -354,7 +355,7 @@ func (e *external) Delete(ctx context.Context, mg resource.Managed) error {
 	}
 
 	opts := deploy.UndeployOptions{
-		DiscoveryClient: e.discovery,
+		DiscoveryClient: memory.NewMemCacheClient(e.discovery),
 		Spec:            cr.Spec.Chart.DeepCopy(),
 		KubeClient:      e.kube,
 		GVR:             tools.ToGroupVersionResource(gvk),

--- a/internal/tools/crdInfo/crdInfo.go
+++ b/internal/tools/crdInfo/crdInfo.go
@@ -13,7 +13,8 @@ import (
 )
 
 type Names struct {
-	Kind string `json:"kind"`
+	Kind   string `json:"kind"`
+	Plural string `json:"plural"`
 }
 type Version struct {
 	Name string `json:"name"`
@@ -31,7 +32,9 @@ type CRD struct {
 }
 
 type CRDInfo struct {
-	schema.GroupVersionKind
+	Kind     string
+	Resource string
+	schema.GroupVersion
 	Namespaced bool
 }
 
@@ -63,11 +66,12 @@ func GetCRDInfoList(pkg *chartfs.ChartFS) ([]CRDInfo, error) {
 			}
 			for _, version := range crd.Spec.Versions {
 				gvk := CRDInfo{
-					GroupVersionKind: schema.GroupVersionKind{
+					GroupVersion: schema.GroupVersion{
 						Group:   crd.Spec.Group,
 						Version: version.Name,
-						Kind:    crd.Spec.Names.Kind,
 					},
+					Kind:       crd.Spec.Names.Kind,
+					Resource:   crd.Spec.Names.Plural,
 					Namespaced: crd.Spec.Scope == "Namespaced",
 				}
 				crdList = append(crdList, gvk)

--- a/internal/tools/deploy/deploy.go
+++ b/internal/tools/deploy/deploy.go
@@ -19,7 +19,7 @@ import (
 )
 
 type UndeployOptions struct {
-	DiscoveryClient discovery.DiscoveryInterface
+	DiscoveryClient discovery.CachedDiscoveryInterface
 	KubeClient      client.Client
 	NamespacedName  types.NamespacedName
 	GVR             schema.GroupVersionResource
@@ -132,7 +132,7 @@ func Undeploy(ctx context.Context, kube client.Client, opts UndeployOptions) err
 }
 
 type DeployOptions struct {
-	DiscoveryClient discovery.DiscoveryInterface
+	DiscoveryClient discovery.CachedDiscoveryInterface
 	KubeClient      client.Client
 	NamespacedName  types.NamespacedName
 	Spec            *definitionsv1alpha1.ChartInfo


### PR DESCRIPTION
 - GroupKind is used to search resources installed in the cluster using RESTmapper, an error is returned in the resource status if resource definition is not installed in the cluster