### PR TITLE
clientConfig service templating in generated CRD

### DIFF
--- a/internal/controllers/compositiondefinitions/compositiondefinitions.go
+++ b/internal/controllers/compositiondefinitions/compositiondefinitions.go
@@ -32,6 +32,7 @@ import (
 	crdtools "github.com/krateoplatformops/core-provider/internal/tools/crd"
 	"github.com/krateoplatformops/core-provider/internal/tools/deploy"
 	"github.com/krateoplatformops/core-provider/internal/tools/deployment"
+	"github.com/krateoplatformops/core-provider/internal/tools/env"
 	"github.com/krateoplatformops/crdgen"
 	rtv1 "github.com/krateoplatformops/provider-runtime/apis/common/v1"
 	"github.com/krateoplatformops/provider-runtime/pkg/controller"
@@ -74,6 +75,8 @@ var (
 	}
 	compositionConversionWebhook = conversion.NewWebhookHandler(runtime.NewScheme())
 	cabundle                     = GetCABundle()
+	webhookServiceName           = env.GetEnvOrDefault("CORE_PROVIDER_WEBHOOK_SERVICE_NAME", "core-provider-webhook-service")
+	webhookServiceNamespace      = env.GetEnvOrDefault("CORE_PROVIDER_WEBHOOK_SERVICE_NAMESPACE", "default")
 )
 
 func GetCABundle() []byte {
@@ -346,8 +349,8 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) error {
 				ConversionReviewVersions: []string{"v1", "v1alpha1", "v1alpha2"},
 				ClientConfig: &apiextensionsv1.WebhookClientConfig{
 					Service: &apiextensionsv1.ServiceReference{
-						Namespace: "default",
-						Name:      "core-provider-webhook-service",
+						Namespace: webhookServiceNamespace,
+						Name:      webhookServiceName,
 						Port:      &whport,
 						Path:      &whpath,
 					},

--- a/internal/tools/env/env.go
+++ b/internal/tools/env/env.go
@@ -1,0 +1,11 @@
+package env
+
+import "os"
+
+func GetEnvOrDefault(key, defaultValue string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+
+	return defaultValue
+}


### PR DESCRIPTION
Adds CORE_PROVIDER_WEBHOOK_SERVICE_NAME and CORE_PROVIDER_WEBHOOK_SERVICE_NAMESPACE envvars to enable template of clientConfig in the generated CRD

Defaults for variables are
CORE_PROVIDER_WEBHOOK_SERVICE_NAMESPACE: "default"
CORE_PROVIDER_WEBHOOK_SERVICE_NAME: "core-provider-webhook-service"