### PR TITLE
Implement JSON logging for logs-ingester compatibility

### DIFF
--- a/internal/controllers/compositiondefinitions/webhooks/conversion/conversion.go
+++ b/internal/controllers/compositiondefinitions/webhooks/conversion/conversion.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/krateoplatformops/core-provider/internal/controllers/compositiondefinitions/webhooks/utils/convertible"
 	webhooktelemetry "github.com/krateoplatformops/core-provider/internal/telemetry/webhooks"
-	prettylog "github.com/krateoplatformops/plumbing/slogs/pretty"
+	"github.com/krateoplatformops/core-provider/internal/tools/loghandler"
 	"github.com/krateoplatformops/provider-runtime/pkg/logging"
 
 	apix "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -26,17 +26,9 @@ func NewWebhookHandler(scheme *runtime.Scheme, metrics ...*webhooktelemetry.Metr
 		recorder = metrics[0]
 	}
 
-	lh := prettylog.New(&slog.HandlerOptions{
-		Level:     slog.LevelError,
-		AddSource: false,
-	},
-		prettylog.WithDestinationWriter(os.Stderr),
-		prettylog.WithColor(),
-		prettylog.WithOutputEmptyAttrs(),
-	)
-
-	logrlog := logr.FromSlogHandler(slog.New(lh).Handler())
-	log := logging.NewLogrLogger(logrlog)
+	// JSON logs, one object per line, for logs-ingester compatibility.
+	// See docs/log-ingester-compatibility.md.
+	log := logging.NewLogrLogger(logr.FromSlogHandler(loghandler.NewJSONHandler(slog.LevelError, os.Stderr)))
 
 	return &webhook{scheme: scheme, log: log.WithName("core-provider-conversion-webhook"), metrics: recorder}
 }

--- a/internal/tools/loghandler/loghandler.go
+++ b/internal/tools/loghandler/loghandler.go
@@ -1,0 +1,44 @@
+// Package loghandler provides the slog handler used across the core-provider.
+//
+// It emits logs as one JSON object per line on the given writer, with the time
+// field rendered as `timestamp` in RFC3339Nano UTC and a persistent `service`
+// attribute. This format is required by logs-ingester, which discards any line
+// that is not a valid JSON object and parses `timestamp` with
+// time.Parse(time.RFC3339Nano, ...). See docs/log-ingester-compatibility.md.
+package loghandler
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"time"
+)
+
+// ServiceName is emitted as the `service` attribute on every log line and is
+// mapped to the service_name column by logs-ingester.
+const ServiceName = "core-provider"
+
+// NewJSONHandler returns a slog.Handler that writes one JSON object per line to
+// w (defaulting to os.Stderr when nil). The standard time field is renamed to
+// `timestamp` and formatted as RFC3339Nano in UTC, and every record carries the
+// `service` attribute.
+func NewJSONHandler(level slog.Leveler, w io.Writer) slog.Handler {
+	if w == nil {
+		w = os.Stderr
+	}
+
+	h := slog.NewJSONHandler(w, &slog.HandlerOptions{
+		Level:     level,
+		AddSource: false,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			// Only rewrite the top-level time field, not nested attributes that
+			// happen to share the key.
+			if len(groups) == 0 && a.Key == slog.TimeKey {
+				return slog.String("timestamp", a.Value.Time().UTC().Format(time.RFC3339Nano))
+			}
+			return a
+		},
+	})
+
+	return h.WithAttrs([]slog.Attr{slog.String("service", ServiceName)})
+}

--- a/internal/tools/loghandler/loghandler_test.go
+++ b/internal/tools/loghandler/loghandler_test.go
@@ -1,0 +1,77 @@
+package loghandler
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestNewJSONHandlerLineIsIngesterCompatible asserts that every emitted line is
+// a single valid JSON object carrying the fields logs-ingester relies on:
+// a `timestamp` parsable as RFC3339Nano, plus `level`, `msg` and `service`.
+func TestNewJSONHandlerLineIsIngesterCompatible(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(NewJSONHandler(slog.LevelInfo, &buf))
+
+	log.Info("order processed", "traceId", "abc-123")
+
+	out := strings.TrimRight(buf.String(), "\n")
+	if strings.Contains(out, "\n") {
+		t.Fatalf("expected a single line per event, got multiple:\n%s", out)
+	}
+
+	var rec map[string]any
+	if err := json.Unmarshal([]byte(out), &rec); err != nil {
+		t.Fatalf("emitted line is not valid JSON: %v\nline: %s", err, out)
+	}
+
+	ts, ok := rec["timestamp"].(string)
+	if !ok || ts == "" {
+		t.Fatalf("missing/empty `timestamp` field: %#v", rec["timestamp"])
+	}
+	if _, exists := rec[slog.TimeKey]; exists {
+		t.Fatalf("default %q key must be renamed to `timestamp`", slog.TimeKey)
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, ts)
+	if err != nil {
+		t.Fatalf("timestamp %q is not RFC3339Nano: %v", ts, err)
+	}
+	if parsed.Location() != time.UTC {
+		t.Errorf("timestamp should be UTC, got %s", parsed.Location())
+	}
+	if !strings.HasSuffix(ts, "Z") {
+		t.Errorf("timestamp should carry the UTC `Z` suffix, got %q", ts)
+	}
+
+	if got := rec["service"]; got != ServiceName {
+		t.Errorf("service = %v, want %q", got, ServiceName)
+	}
+	if got := rec["msg"]; got != "order processed" {
+		t.Errorf("msg = %v, want %q", got, "order processed")
+	}
+	if got := rec["level"]; got != "INFO" {
+		t.Errorf("level = %v, want INFO", got)
+	}
+	if got := rec["traceId"]; got != "abc-123" {
+		t.Errorf("traceId = %v, want abc-123", got)
+	}
+}
+
+// TestNewJSONHandlerRespectsLevel ensures the configured level filters records.
+func TestNewJSONHandlerRespectsLevel(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(NewJSONHandler(slog.LevelError, &buf))
+
+	log.Info("should be filtered out")
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output below the configured level, got: %s", buf.String())
+	}
+
+	log.Error("kept")
+	if buf.Len() == 0 {
+		t.Fatal("expected error-level record to be emitted")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -15,10 +16,10 @@ import (
 	"github.com/krateoplatformops/core-provider/internal/controllers/compositiondefinitions"
 	webhooktelemetry "github.com/krateoplatformops/core-provider/internal/telemetry/webhooks"
 	"github.com/krateoplatformops/core-provider/internal/tools/certs"
+	"github.com/krateoplatformops/core-provider/internal/tools/loghandler"
 	"github.com/krateoplatformops/core-provider/internal/tools/pluralizer"
 	"github.com/krateoplatformops/plumbing/env"
 	"github.com/krateoplatformops/plumbing/ptr"
-	prettylog "github.com/krateoplatformops/plumbing/slogs/pretty"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/config"
@@ -66,45 +67,31 @@ func main() {
 
 	log.Default().SetOutput(os.Stderr)
 
-	if *tlsCertificateDuration < time.Minute*10 {
-		log.Fatalf("The TLS certificate duration must be at least 10 minutes.")
-		return
-	}
-	if *tlsCertificateDuration < time.Duration(3)*(*pollInterval) {
-		log.Fatalf("The TLS certificate duration must be at least 3 times the poll interval.")
-		return
-	}
-	if *tlsCertificateLeaseExpirationMargin > *tlsCertificateDuration {
-		log.Fatalf("The TLS certificate lease expiration margin must be less than the TLS certificate duration.")
-		return
-	}
-
 	logLevel := slog.LevelInfo
 	if *debug {
 		logLevel = slog.LevelDebug
 	}
 
-	lh := prettylog.New(&slog.HandlerOptions{
-		Level:     logLevel,
-		AddSource: false,
-	},
-		prettylog.WithDestinationWriter(os.Stderr),
-		prettylog.WithColor(),
-		prettylog.WithOutputEmptyAttrs(),
-	)
+	// Emit logs as one JSON object per line (RFC3339Nano UTC `timestamp` plus a
+	// `service` attribute) so they can be ingested by logs-ingester. See
+	// docs/log-ingester-compatibility.md.
+	log := logging.NewLogrLogger(logr.FromSlogHandler(loghandler.NewJSONHandler(logLevel, os.Stderr)))
 
-	logrlog := logr.FromSlogHandler(slog.New(lh).Handler())
-	log := logging.NewLogrLogger(logrlog)
+	// Set the logger for controller-runtime. This only has to log in INFO level as all debug logs are handled by our logger above.
+	ctrl.SetLogger(logr.FromSlogHandler(loghandler.NewJSONHandler(slog.LevelInfo, os.Stderr)))
 
-	// Set the logger for controller-runtime. This only have to log in INFO level as all debug logs are handled by our logger above.
-	ctrl.SetLogger(logr.FromSlogHandler(slog.New(prettylog.New(&slog.HandlerOptions{
-		Level:     slog.LevelInfo,
-		AddSource: false,
-	},
-		prettylog.WithDestinationWriter(os.Stderr),
-		prettylog.WithColor(),
-		prettylog.WithOutputEmptyAttrs(),
-	)).Handler()))
+	if *tlsCertificateDuration < time.Minute*10 {
+		log.Error(errors.New("invalid TLS certificate configuration"), "The TLS certificate duration must be at least 10 minutes.")
+		os.Exit(1)
+	}
+	if *tlsCertificateDuration < time.Duration(3)*(*pollInterval) {
+		log.Error(errors.New("invalid TLS certificate configuration"), "The TLS certificate duration must be at least 3 times the poll interval.")
+		os.Exit(1)
+	}
+	if *tlsCertificateLeaseExpirationMargin > *tlsCertificateDuration {
+		log.Error(errors.New("invalid TLS certificate configuration"), "The TLS certificate lease expiration margin must be less than the TLS certificate duration.")
+		os.Exit(1)
+	}
 
 	log.Debug("Starting",
 		"sync-period", syncPeriod.String(),


### PR DESCRIPTION
Replace the prettylog (colored, human-readable) handlers with a self-contained JSON slog handler so every log line is a single JSON object with an RFC3339Nano UTC `timestamp` and a `service` attribute, as required by logs-ingester.

- add internal/tools/loghandler with NewJSONHandler + tests
- switch main.go (app + controller-runtime loggers) to JSON and move logger creation before TLS validation; replace log.Fatalf with log.Error + os.Exit so startup errors are JSON too
- switch the conversion webhook logger to JSON